### PR TITLE
Use "env." in the configuration example

### DIFF
--- a/bird
+++ b/bird
@@ -22,8 +22,8 @@ This configuration snipplet is an example with the defaults:
 
   [bird]
     user root
-    protocols BGP
-    socket /var/run/bird.ctl
+    env.protocols BGP
+    env.socket /var/run/bird.ctl
 
 =head1 USAGE
 


### PR DESCRIPTION
The munin plugin configuration needs all variables to be prefixed with "env.".  This patch adds this to the configuration example in the plugin.
